### PR TITLE
Fixed typo to get oauth token.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ class TwitterLogin extends Component {
             const oauthVerifier = query.get('oauth_verifier');
 
             closeDialog();
-            return this.getOuathToken(oauthVerifier, oauthToken);
+            return this.getOauthToken(oauthVerifier, oauthToken);
           } else {
             closeDialog();
             return this.props.onFailure(new Error(


### PR DESCRIPTION
As per PR fixes - https://github.com/GenFirst/react-twitter-auth/pull/6 there was typo in method name and because of that it stopped working. With this fix it should work fine.