### PR TITLE
prevent button click from reloading page

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,8 @@ class TwitterLogin extends Component {
     this.onButtonClick = this.onButtonClick.bind(this);
   }
 
-  onButtonClick() {
+  onButtonClick(e) {
+    e.preventDefault();
     return this.getRequestToken();
   }
 


### PR DESCRIPTION
This was causing issues for me during development, the page would reload before the `getRequestToken` calls would finish causing the popup to have a blank white page.

I think this may fix this issue: https://github.com/GenFirst/react-twitter-auth/issues/19