### PR TITLE
Bump React peer dependency to v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "url": "https://github.com/GenFirst/react-twitter-login/issues"
   },
   "peerDependencies": {
-    "react": "^16.6.3",
-    "react-dom": "^16.6.3",
-    "prop-types": "^15.5.0"
+    "react": "> 15.5.0 < 17",
+    "react-dom": "> 15.5.0 < 17",
+    "prop-types": "> 15.5.0 < 17"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "url": "https://github.com/GenFirst/react-twitter-login/issues"
   },
   "peerDependencies": {
-    "react": "^15.5.0",
-    "react-dom": "^15.5.0",
+    "react": "^16.6.3",
+    "react-dom": "^16.6.3",
     "prop-types": "^15.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I've been using `react-twitter-auth` with `react@16` for a month now, without any issues.